### PR TITLE
SweetSpot World 3 Implemented

### DIFF
--- a/src/composables/SweetSpot.ts
+++ b/src/composables/SweetSpot.ts
@@ -306,7 +306,7 @@ export const Monsters: Monster[] = [
     accHigh: 825,
     respawnRate: 40,
     numMobs: 15,
-    weight: 0,
+    weight: 7,
   },
   {
     name: "Frost Flake",
@@ -317,7 +317,7 @@ export const Monsters: Monster[] = [
     accHigh: 1050,
     respawnRate: 40,
     numMobs: 13,
-    weight: 0,
+    weight: 5.8,
   },
   {
     name: "Sir Stache",
@@ -328,7 +328,7 @@ export const Monsters: Monster[] = [
     accHigh: 1350,
     respawnRate: 40,
     numMobs: 20,
-    weight: 0,
+    weight: 10,
   },
   {
     name: "Bloque",
@@ -339,7 +339,7 @@ export const Monsters: Monster[] = [
     accHigh: 1725,
     respawnRate: 40,
     numMobs: 19,
-    weight: 0,
+    weight: 7.5,
   },
   {
     name: "Mamooth",
@@ -350,7 +350,7 @@ export const Monsters: Monster[] = [
     accHigh: 2100,
     respawnRate: 40,
     numMobs: 19,
-    weight: 0,
+    weight: 7.8,
   },
   {
     name: "Snowman",
@@ -361,7 +361,7 @@ export const Monsters: Monster[] = [
     accHigh: 2550,
     respawnRate: 40,
     numMobs: 14,
-    weight: 0,
+    weight: 3,
   },
   {
     name: "Penguin",
@@ -372,7 +372,7 @@ export const Monsters: Monster[] = [
     accHigh: 3000,
     respawnRate: 40,
     numMobs: 13,
-    weight: 0,
+    weight: 4.5,
   },
   {
     name: "Thermister",
@@ -383,7 +383,7 @@ export const Monsters: Monster[] = [
     accHigh: 3375,
     respawnRate: 40,
     numMobs: 18,
-    weight: 0,
+    weight: 7,
   },
   {
     name: "Quenchie",
@@ -394,7 +394,7 @@ export const Monsters: Monster[] = [
     accHigh: 3900,
     respawnRate: 40,
     numMobs: 19,
-    weight: 0,
+    weight: 7,
   },
   {
     name: "Cryosnake",
@@ -405,7 +405,7 @@ export const Monsters: Monster[] = [
     accHigh: 4350,
     respawnRate: 40,
     numMobs: 20,
-    weight: 0,
+    weight: 6,
   },
   {
     name: "Bop Box",
@@ -416,7 +416,7 @@ export const Monsters: Monster[] = [
     accHigh: 4800,
     respawnRate: 40,
     numMobs: 17,
-    weight: 0,
+    weight: 7,
   },
   {
     name: "Neyeptune",
@@ -427,7 +427,7 @@ export const Monsters: Monster[] = [
     accHigh: 5100,
     respawnRate: 40,
     numMobs: 14,
-    weight: 0,
+    weight: 2,
   },
   {
     name: "Dedotated Ram",
@@ -438,17 +438,6 @@ export const Monsters: Monster[] = [
     accHigh: 2250,
     respawnRate: 35,
     numMobs: 20,
-    weight: 3.8,
-  },
-  {
-    name: "Bloodbone",
-    attack: 3000,
-    health: 10000000,
-    exp: 6000,
-    accLow: 50,
-    accHigh: 150,
-    respawnRate: 40,
-    numMobs: 1,
-    weight: 0,
+    weight: 3,
   },
 ];

--- a/src/composables/SweetSpot.ts
+++ b/src/composables/SweetSpot.ts
@@ -305,7 +305,7 @@ export const Monsters: Monster[] = [
     accLow: 275,
     accHigh: 825,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 15,
     weight: 0,
   },
   {
@@ -316,7 +316,7 @@ export const Monsters: Monster[] = [
     accLow: 350,
     accHigh: 1050,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 13,
     weight: 0,
   },
   {
@@ -327,7 +327,7 @@ export const Monsters: Monster[] = [
     accLow: 450,
     accHigh: 1350,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 20,
     weight: 0,
   },
   {
@@ -338,7 +338,7 @@ export const Monsters: Monster[] = [
     accLow: 575,
     accHigh: 1725,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 19,
     weight: 0,
   },
   {
@@ -349,7 +349,7 @@ export const Monsters: Monster[] = [
     accLow: 700,
     accHigh: 2100,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 19,
     weight: 0,
   },
   {
@@ -360,7 +360,7 @@ export const Monsters: Monster[] = [
     accLow: 850,
     accHigh: 2550,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 14,
     weight: 0,
   },
   {
@@ -371,7 +371,7 @@ export const Monsters: Monster[] = [
     accLow: 1000,
     accHigh: 3000,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 13,
     weight: 0,
   },
   {
@@ -382,7 +382,7 @@ export const Monsters: Monster[] = [
     accLow: 1125,
     accHigh: 3375,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 18,
     weight: 0,
   },
   {
@@ -393,7 +393,7 @@ export const Monsters: Monster[] = [
     accLow: 1300,
     accHigh: 3900,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 19,
     weight: 0,
   },
   {
@@ -404,7 +404,7 @@ export const Monsters: Monster[] = [
     accLow: 1450,
     accHigh: 4350,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 20,
     weight: 0,
   },
   {
@@ -415,7 +415,7 @@ export const Monsters: Monster[] = [
     accLow: 1600,
     accHigh: 4800,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 17,
     weight: 0,
   },
   {
@@ -426,7 +426,7 @@ export const Monsters: Monster[] = [
     accLow: 1700,
     accHigh: 5100,
     respawnRate: 40,
-    numMobs: 1,
+    numMobs: 14,
     weight: 0,
   },
   {
@@ -437,8 +437,8 @@ export const Monsters: Monster[] = [
     accLow: 750,
     accHigh: 2250,
     respawnRate: 35,
-    numMobs: 1,
-    weight: 0,
+    numMobs: 20,
+    weight: 3.8,
   },
   {
     name: "Bloodbone",

--- a/src/pages/SweetSpot.vue
+++ b/src/pages/SweetSpot.vue
@@ -3,7 +3,7 @@
     Find the best EXP farming spot for your character! This tool takes into
     account respawn time, map complexity, and the number of monsters that appear
     on the map.
-    <u>Active gains will not be the same as your AFK gains.</u> World 3 is WIP.
+    <u>Active gains will not be the same as your AFK gains.</u>
     <template v-slot:action>
       <q-btn-dropdown outline label="Wiki">
         <q-list separator>
@@ -164,6 +164,12 @@
           </div>
         </div>
       </div>
+      <div class="text-xl">Feedback</div>
+      <div>
+        The SweetSpot logic is maintained by #100mar with the UI created by #adapap. If there are any questions regarding the best farming spots, please visit the public Idleon Companion discord server found in the <a href="/Changelog" style="color:#5bc0de">Changelog</a>.
+        This tool was created using data from multiple Idleon characters to tweak the results of the calculator. <br>
+        Below is an in-depth table of values. For any monster that takes 15+ Average hits to kill, it will show up as "0.0".
+      </div>
     </q-card-section>
     <q-card-section>
       <q-table
@@ -274,6 +280,16 @@ export default defineComponent({
     const multiHitDamage = computed(() => {
        let damageArr = [1.00];
       switch (currentCharacter.value?.class) {
+        case Class.Warrior:
+          damageArr.push(1.00);
+          break;
+        case Class.Archer:
+          damageArr.push(1.00);
+          break;
+        case Class.Hunter:
+          damageArr.push(1.00);
+          damageArr.push(1.00);
+          break;
         case Class.Journeyman:
           // Basic attacks do more damage
           damageArr[0] = 1 + 0.6*stats.skill1Lvl;
@@ -483,12 +499,15 @@ export default defineComponent({
       return n !== Infinity && !isNaN(n);
     };
 
-    /*
-     * The next two functions are technically not the real min/max
-     * They are used to calculate avgHitToKill.
-     */
     const avgMinHitToKill = (monster: Monster): number => {
-      let hit = monster.health / (stats.maxDmg * multiHitMultiplier.value);
+      let dmgMul = 0;
+      // Assume you hit your multi-hit skills 100% of the time.
+      for(let i = 0; i < numberOfAttacks.value; i++){
+        dmgMul = dmgMul + multiHitDamage.value[i];
+      }
+      // Assume crit
+      let bestHit = stats.maxDmg*stats.critDmg*dmgMul;
+      let hit = monster.health / (bestHit);
       if (!isValidNumber(hit)) {
         return 0;
       }
@@ -496,7 +515,7 @@ export default defineComponent({
     };
 
     const avgMaxHitToKill = (monster: Monster): number => {
-      let hit = monster.health / (stats.minDmg * multiHitMultiplier.value);
+      let hit = monster.health / (stats.minDmg);
       if (!isValidNumber(hit)) {
         return 0;
       }


### PR DESCRIPTION
### Changes & Improvements

- [x] World 3 Mobs Added
- [x] Fixed the incorrect calculation in Average number of Hits.
- [x] Multi-hit skills added for Journeyman & Maestro
- [x] Min/Max hits in the Table is accurate
- [x] Added "Feedback" section underneath Best mobs
- [x] Avg hits only calculates when necessary.

What can be changed, but the SweetSpot works fine without these fixes
- [ ] A bug with Multi-hit skills. It shows "Skill 2" even though I'm on my Archer.
![image](https://user-images.githubusercontent.com/13767112/134789317-2ae09e4d-c66e-40ae-baf1-214679fb6d83.png)
- [ ] Maestro Triple Jab does not show
![image](https://user-images.githubusercontent.com/13767112/134789326-716ae746-ab9f-4e0c-82bb-70f84f545b12.png)
- [ ] A "Compute" button. I'm worried on slower computers the website may appear unresponsive.
