### PR TITLE
Fix #189: added min/max, q-input rule

### DIFF
--- a/src/components/characters/CharacterEditor.vue
+++ b/src/components/characters/CharacterEditor.vue
@@ -51,6 +51,11 @@
             outlined
             type="number"
             class="mr-2 mb-2 w-1/2 md:w-1/3 lg:w-1/4"
+            :min="0"
+            :max="9999"
+            :rules="[
+              (val) => (val >= 0 && val < 9999) || 'Positive integers only',
+            ]"
           >
             <template v-slot:prepend>
               <Tooltip>


### PR DESCRIPTION
This still allows the entry of negative numbers explicitly, but the spinners behave properly. I am looking into managing the explicit input behavior, but this works for now and the spinners no longer go negative.