### PR TITLE
Fix Stamp Costs

### DIFF
--- a/src/components/tracker/StampTracker.vue
+++ b/src/components/tracker/StampTracker.vue
@@ -82,7 +82,7 @@
                     Next material cost:
                     {{
                       stamp.diffRatio -
-                      (stamps[stamp.name] ?? 0 % stamp.diffRatio)
+                      ((stamps[stamp.name] ?? 0) % stamp.diffRatio)
                     }}
                   </div>
                 </div>

--- a/src/composables/Stamps.ts
+++ b/src/composables/Stamps.ts
@@ -1122,7 +1122,7 @@ export function useStamps() {
     return Math.floor(
       s.baseCoinCost *
         Math.pow(
-          s.powCoinBase - (lvl / (lvl + 5 * s.diffRatio)) * 0.25,
+          s.powCoinBase - (+lvl / (+lvl + 5 * s.diffRatio)) * 0.25,
           lvl * (10 / s.diffRatio)
         )
     );


### PR DESCRIPTION
Forced integer arithmetic via +, added parenthesis to have correct material costs.

Stamps are now consistent with wiki.
![image](https://user-images.githubusercontent.com/13767112/140240282-2b70232f-1ed0-4fdb-baee-03e3fe30e7c4.png)
![image](https://user-images.githubusercontent.com/13767112/140240299-18378729-1fa8-4975-a3f3-3422e620755d.png)

