### PR TITLE
Fixed Alchemy Costs

### DIFF
--- a/src/components/alchemy/AlchemyBubbleRow.vue
+++ b/src/components/alchemy/AlchemyBubbleRow.vue
@@ -103,17 +103,35 @@ export default defineComponent({
       let discountBy = (100 - props.discount) / 100;
       let materialCosts = cloneDeep(bubbleInfo.value.Materials);
       // Sum all materials of the different levels together into the histogram
-      for (let i = alchemyUpgrade.value; i < alchemyGoal.value - 1; i += 1) {
-        let levelMulti = Math.pow(1.35 - (0.3 * i) / (50 + i), i);
+      
+      // Hold the total cost in case goal is higher than current level by 2 or more
+      let totalCosts = Array(bubbleInfo.value.Materials.length);
+      for ( let costIndex = 0; costIndex < totalCosts.length; costIndex ++){
+        totalCosts[costIndex] = 0;
+      }
+
+      // For each level, calcualte the material cost. Then add it to the total cost.
+      for (let bubbleLevel = alchemyUpgrade.value; bubbleLevel < alchemyGoal.value; bubbleLevel += 1) {
+        let levelMulti = Math.pow(1.35 - (0.3 * bubbleLevel) / (50 + bubbleLevel), bubbleLevel);
         bubbleInfo.value.Materials.forEach((material, index) => {
           if (material.isLiquid) {
-            materialCosts[index].Amount += material.Amount + Math.floor(i / 20);
+            totalCosts[index] += materialCosts[index].Amount + Math.floor(bubbleLevel / 20);
           } else {
-            materialCosts[index].Amount +=
-              material.Amount * levelMulti * discountBy;
+            totalCosts[index] += material.Amount * levelMulti * discountBy;
           }
         });
       }
+      
+      // Edge-case if Goal=Upgrade level. Show no materials.
+      bubbleInfo.value.Materials.forEach((material, index) => {
+        if(alchemyUpgrade.value == alchemyGoal.value) {
+          materialCosts[index].Amount = 0;
+        }
+        else{
+          materialCosts[index].Amount = totalCosts[index];
+        }
+      });
+      
       return materialCosts;
     });
 

--- a/src/components/alchemy/AlchemyBubbles.vue
+++ b/src/components/alchemy/AlchemyBubbles.vue
@@ -5,7 +5,7 @@
       <q-input
         v-model.number="cauldronLevel"
         type="number"
-        label="Cauldron Level"
+        label="Cauldron Boost Cost Level"
         filled
         :min="0"
       />
@@ -37,6 +37,17 @@
       <div class="text-secondary p-1">
         {{ `-${discount["Underdeveloped Costs/Barley Brew"].toFixed(1)}%` }}
       </div>
+    </div>
+    <div class="flex flex-col justify-end px-2">
+      <div class="text-lg">Obtained S-M-R-T</div>
+      <div class="q-gutter-sm">
+      <q-checkbox
+        v-model="hasAchievement"
+        color="secondary"
+        true-value=1
+        false-value=0
+      />
+    </div>
     </div>
     <div class="flex flex-col justify-end px-2 text-green-500">
       <div class="text-lg">Total Discount</div>
@@ -122,6 +133,7 @@ export default defineComponent({
     const { calculateBubbleDiscount } = useAlchemy();
 
     const currentCauldron = ref<AlchemyColor>("Orange");
+    const hasAchievement = ref(0);
 
     const cauldronLevel = ref(0);
     const bargainTagLevel = ref(0);
@@ -144,13 +156,15 @@ export default defineComponent({
       Assets,
       bargainTagLevel,
       bubbleCount: AlchemyConst.BubbleCount,
+      hasAchievement,
       discount: computed(() =>
         calculateBubbleDiscount(
           cauldronLevel.value,
           bargainTagLevel.value,
           bargainBubble.value,
           undevCosts.value,
-          barleyBrew.value
+          barleyBrew.value,
+          hasAchievement.value,
         )
       ),
       cauldronLevel,

--- a/src/composables/Alchemy.ts
+++ b/src/composables/Alchemy.ts
@@ -1,3 +1,4 @@
+import { connect } from "http2";
 import { Growth } from "~/composables/Utilities";
 import bubbleData from "~/data/bubbles.json";
 
@@ -338,7 +339,8 @@ export function useAlchemy() {
     bargainTagLevel: number,
     bargainBubble: number,
     undevCosts: number,
-    barleyBrew: number
+    barleyBrew: number,
+    hasAchievement: number,
   ) => {
     const precision = Math.pow(10, 4);
 
@@ -353,7 +355,8 @@ export function useAlchemy() {
     const vial = Growth.Add(barleyBrew, 1, 0);
     const undev_vial = Math.max(0.05, 1 - (undevCost + vial) / 100);
     const bargain_tag = Math.max(Math.pow(0.75, bargainTagLevel), 0.1);
-    const discount = oa * newBubble * undev_vial * bargain_tag;
+    const achieve_discount = +hasAchievement ? 0.90 : 1;
+    const discount = oa * newBubble * undev_vial * bargain_tag * achieve_discount;
     const roundToPrecision = (n: number): number =>
       (precision - Math.round(n * precision)) / 100;
     return {

--- a/src/composables/Alchemy.ts
+++ b/src/composables/Alchemy.ts
@@ -355,7 +355,7 @@ export function useAlchemy() {
     const vial = Growth.Add(barleyBrew, 1, 0);
     const undev_vial = Math.max(0.05, 1 - (undevCost + vial) / 100);
     const bargain_tag = Math.max(Math.pow(0.75, bargainTagLevel), 0.1);
-    const achieve_discount = +hasAchievement ? 0.90 : 1;
+    const achieve_discount = hasAchievement ? 0.90 : 1;
     const discount = oa * newBubble * undev_vial * bargain_tag * achieve_discount;
     const roundToPrecision = (n: number): number =>
       (precision - Math.round(n * precision)) / 100;


### PR DESCRIPTION
# Bug Fixes
- This should match in-game values much better. Still doesn't seem perfect, but it's very close where I'm happy with it.
- Having a goal +2 higher will now correctly add values as expected. 
- SMRT bubble is now accounted for.

**Examples:**
![image](https://user-images.githubusercontent.com/13767112/140249254-407a9c38-2fab-41fd-b16c-769e3a6b0cff.png)
![image](https://user-images.githubusercontent.com/13767112/140249269-9cf11aee-db58-495c-b584-8c269a76ec86.png)

![image](https://user-images.githubusercontent.com/13767112/140249285-565f379b-74c3-4157-8afc-c3504521bc55.png)
![image](https://user-images.githubusercontent.com/13767112/140249293-a4d8344d-fa0a-48b8-a028-28b29fb8baf6.png)


