### PR TITLE
Equipment Tracker v1

### DIFF
--- a/src/composables/Characters.ts
+++ b/src/composables/Characters.ts
@@ -80,12 +80,81 @@ export const Skills = [
 ] as const;
 export type Skill = typeof Skills[number];
 
+type MiscEffect = {
+  effect: string;
+  value: number;
+};
+
+export enum EquipmentType {
+  Weapon = "Weapon",
+
+  Helmet = "Helmet",
+  Shirt = "Shirt",
+  Pants = "Pants",
+  Shoes = "Shoes",
+  Pendant = "Pendant",
+  Ring = "Ring",
+  Keychain = "Keychain",
+
+  Axe = "Axe",
+  Pickaxe = "Pickaxe",
+  Fishing_Rod = "Fishing_Rod",
+  Catching_Net = "Catching_Net",
+  Trap_Box = "Trap_Box",
+  Worship_Skull = "Worship_Skull",
+
+  Premium_Helmet = "Premium_Helmet",
+  Premium_Ring = "Premium_Ring",
+  Trophy = "Trophy",
+
+  Nothing = "Nothing",
+}
+
+export type Equippable = {
+  name: string;
+  type: EquipmentType;
+  class: Class; // This class and subclasses are able to use this equippable
+  weaponPower: number;
+  speed: number;
+  defense: number;
+  strength: number;
+  agility: number;
+  wisdom: number;
+  luck: number;
+  reach: number;
+  miscellaneous: MiscEffect[];
+};
+
+export const EquipmentSlot = <const>[
+  "helmet",
+  "shirt",
+  "pants",
+  "shoes",
+  "weapon",
+  "pendant",
+  "ring1",
+  "ring2",
+  "axe",
+  "pickaxe",
+  "net",
+  "rod",
+  "box",
+  "skull",
+  "keychain1",
+  "keychain2",
+  "trophy",
+  "premiumHelmet",
+  "premiumRing",
+];
+export type EquipmentSlot = typeof EquipmentSlot[number];
+
 // Characters keep track of individual data
 export class Character {
   public class: Class;
   public level: number;
   public name: string;
   public items: Record<string, boolean>;
+  public equipment: Partial<Record<EquipmentSlot, Equippable>>;
   public skills: Record<Skill, number>;
   public constellations: Record<string, boolean>;
   public starSigns: Record<string, boolean>;
@@ -95,6 +164,7 @@ export class Character {
     this.level = 1;
     this.name = "";
     this.items = {};
+    this.equipment = {};
     this.skills = <Record<Skill, number>>(
       Object.fromEntries(Skills.map((x) => [x, 0]))
     );

--- a/src/composables/Utilities.ts
+++ b/src/composables/Utilities.ts
@@ -50,6 +50,10 @@ export class Assets {
     return Assets.FromDir(c, "classes");
   }
 
+  static EquipmentImage(item: string): string {
+    return Assets.FromDir(item, "equipment");
+  }
+
   static FromDir(item: string, dir: string, extension?: string): string {
     const cleaned = item.replace(/ /g, "_");
     // Use base URL here for GH pages support

--- a/src/pages/Characters.vue
+++ b/src/pages/Characters.vue
@@ -26,6 +26,7 @@
   <CharacterEditor v-else />
   <CharacterProgressTracker v-if="currentCharacter !== null" />
   <Constellations />
+  <Equipment />
 </template>
 
 <script lang="ts">
@@ -38,11 +39,13 @@ import CharacterEditor from "~/components/characters/CharacterEditor.vue";
 import CharacterProgressTracker from "~/components/characters/CharacterProgressTracker.vue";
 import CloudData from "~/components/CloudData.vue";
 import Constellations from "~/components/characters/Constellations.vue";
+import Equipment from "~/components/characters/Equipment.vue";
 
 const wikiLinks = new Map([
   ["Classes", "https://idleon.miraheze.org/wiki/Classes"],
+  ["Classes", "https://idleon.miraheze.org/wiki/Classes"],
   ["Skills", "https://idleon.miraheze.org/wiki/Skills"],
-  ["Items", "https://idleon.miraheze.org/wiki/Items"],
+  ["Items/Equipment", "https://idleon.miraheze.org/wiki/Items"],
   ["Star Signs", "https://idleon.miraheze.org/wiki/Star_Signs"],
 ]);
 
@@ -53,6 +56,7 @@ export default defineComponent({
     CharacterProgressTracker,
     CloudData,
     Constellations,
+    Equipment,
   },
   setup() {
     const { user } = useAuth();


### PR DESCRIPTION
Track equipment per character on the character page. Supports armor, weapons, rings, pendants, tools, trophies, premium helmets/rings.

Clicking on an equipment item shows its stats in a pane next to the selector.

The following content is missing at the moment:
- Probably some of the newest in-game items
- All keychains
- Ability to change stats on equipment (e.g. through upgrade stones)

Closes #143 
Closes #50 