### PR TITLE
Updated App to use Hash Based Routing

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -1,4 +1,4 @@
-import { RouteRecordRaw, createRouter, createWebHistory } from "vue-router";
+import { RouteRecordRaw, createRouter, createWebHashHistory } from "vue-router";
 import { useBuilds } from "~/composables/Builds";
 import Alchemy from "~/pages/Alchemy.vue";
 import Builds from "~/pages/Builds.vue";
@@ -123,7 +123,7 @@ const routes: RouteRecordRaw[] = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes,
 });
 


### PR DESCRIPTION
Updated the app to use a different routing scheme to avoid issues with hosting returning 404s for internal app routes.

I ran the changes locally, and from what I tested the app remains functional. I don't have a gh-pages setup to test against, so was unable to do an end-to-end test of the changes, but they should be quick enough to verify on your end.

Fixes: #228 